### PR TITLE
Added version attribute to define hugo version used in pipeline

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,12 +5,11 @@ LABEL version="latest"
 ARG HUGO_VERSION
 
 COPY ./drone-hugo.sh /bin/
-RUN chmod +x /bin/drone-hugo.sh
 
 RUN apk update
+RUN chmod +x bin/drone-hugo.sh
 RUN mkdir /temp/
-RUN wget https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_Linux-64bit.tar.gz -P /temp
-RUN tar xzvf /temp/hugo_${HUGO_VERSION}_Linux-64bit.tar.gz -C /temp/
+RUN wget -O- https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_Linux-64bit.tar.gz | tar xz -C /temp/
 RUN mv /temp/hugo /bin/hugo
 RUN rm  -rf /temp
 

--- a/Makefile
+++ b/Makefile
@@ -5,23 +5,25 @@ README_TEMPLATE=./docs/tmpl.md
 all: release
 
 test: Dockerfile drone-hugo.sh
-	docker build -t "plugins/hugo:$(hugo)_test" --build-arg HUGO_VERSION="$(hugo)" .
+	docker build -t "plugins/hugo:$(release)_test" --build-arg HUGO_VERSION="$(hugo)" .
 
 build: Dockerfile drone-hugo.sh
-	docker build -t "plugins/hugo:$(hugo)" --build-arg HUGO_VERSION="$(hugo)" .
+	docker build -t "plugins/hugo:$(release)" --build-arg HUGO_VERSION="$(hugo)" .
 	docker build -t "plugins/hugo:latest" --build-arg HUGO_VERSION="$(hugo)" .
 
 push: build
-	docker push "plugins/hugo:$(hugo)"
+	docker push "plugins/hugo:$(release)"
 	docker push "plugins/hugo:latest"
 
-release: $(README_TEMPLATE) test build push clean
-	sed 's/<HUGO_VERSION>/$(hugo)/g' $(README_TEMPLATE) > README.md
+release: $(README_TEMPLATE) test push build clean
+	sed 's/<HUGO_VERSION>/$(hugo)/g' $(README_TEMPLATE) > temp.md
+	sed 's/<RELEASE>/$(release)/g' temp.md > README.md
+	rm -rf temp.md
 	git add .
 	git commit -m "Updated to the latest Hugo version v.$(hugo), see https://github.com/gohugoio/hugo/releases"
 	git push origin master
 
 clean:
-	docker rmi plugins/hugo:$(hugo)
+	docker rmi plugins/hugo:$(release)
 	docker rmi plugins/hugo:latest
-	docker rmi plugins/hugo:$(hugo)_test
+	docker rmi plugins/hugo:$(release)_test

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # drone-hugo
 
-[![GitHub release](https://img.shields.io/github/release/drone-plugins/drone-hugo.svg)](https://github.com/drone-plugins/drone-hugo/releases) ![](https://img.shields.io/badge/hugo%20version-v0.40.2-ff69b4.svg)
+[![GitHub release](https://img.shields.io/github/release/drone-plugins/drone-hugo.svg)](https://github.com/plugins/hugo/releases) ![](https://img.shields.io/badge/hugo%20version-v0.40.2-ff69b4.svg)
 [![Docker Pulls](https://img.shields.io/docker/pulls/plugins/hugo.svg)](https://hub.docker.com/r/plugins/hugo/tags/)
 
 **Automatically create static web page files using Hugo within your drone pipeline!**
 
-drone-plugins/drone-hugo is:
+plugins/hugo is:
 
 - **Easy** to implement in your existing pipeline using `.drone.yml`
 - **Small** 21mb image size
@@ -18,7 +18,7 @@ The example below demonstrates how you can use the plugin to automatically creat
 ```yml
 pipeline:
   hugo:
-    image: plugins/hugo:0.40.2
+    image: plugins/hugo:1.1
     validate: true
 ```
 
@@ -31,7 +31,7 @@ You can customize the paths for e. g. the theme, layout, content directory and o
 ```yml
 pipeline:
   hugo:
-    image: plugins/hugo:0.40.2
+    image: plugins/hugo:1.1
 +   config: path/to/config
 +   content: path/to/content/
 +   layout: path/to/layout
@@ -48,7 +48,7 @@ You can also define a base URL directly in the pipeline, which is used when gene
 ```yml
 pipeline:
   hugo:
-    image: plugins/hugo:0.40.2
+    image: plugins/hugo:1.1
     config: path/to/config
     content: path/to/content/
     output: path/to/public
@@ -69,7 +69,7 @@ You can set the `buildDrafts`, `buildExpired`, `buildFuture` settings to configu
 ```yml
 pipeline:
   hugo:
-    image: plugins/hugo:0.40.2
+    image: plugins/hugo:1.1
 +   buildDrafts: true
 +   buildExpired: true
 +   buildFuture: true
@@ -89,7 +89,7 @@ Here is a short example of how to define a pipeline that automatically generates
 ```yml
 pipeline:
   build:
-    image: plugins/hugo:0.40.2
+    image: plugins/hugo:1.1
     output: site # Output path
     validate: true
     when:
@@ -109,7 +109,7 @@ You can also use secrets to hide credentials:
 ```yml
 pipeline:
   build:
-    image: plugins/hugo:0.40.2
+    image: plugins/hugo:1.1
     output: site # Output path
     validate: true
     when:
@@ -129,6 +129,7 @@ pipeline:
 
 ```bash
 docker run --rm \
+  -e PLUGIN_VERSION=0.40.2 \
   -e PLUGIN_BUILDDRAFTS=false \
   -e PLUGIN_BUILDEXPIRED=false \
   -e PLUGIN_BUILDFUTURE=false \
@@ -147,6 +148,7 @@ docker run --rm \
 
 ## Parameter Reference
 
+`version` - the hugo version to be used, if not set use v.0.40.2  
 `buildDrafts` - include content marked as draft<br>
 `buildExpired` - include expired content<br>
 `buildFuture` - include content with publishdate in the future<br>

--- a/docs/tmpl.md
+++ b/docs/tmpl.md
@@ -18,7 +18,7 @@ The example below demonstrates how you can use the plugin to automatically creat
 ```yml
 pipeline:
   hugo:
-    image: plugins/hugo:<HUGO_VERSION>
+    image: plugins/hugo:<RELEASE>
     validate: true
 ```
 
@@ -31,7 +31,7 @@ You can customize the paths for e. g. the theme, layout, content directory and o
 ```yml
 pipeline:
   hugo:
-    image: plugins/hugo:<HUGO_VERSION>
+    image: plugins/hugo:<RELEASE>
 +   config: path/to/config
 +   content: path/to/content/
 +   layout: path/to/layout
@@ -48,7 +48,7 @@ You can also define a base URL directly in the pipeline, which is used when gene
 ```yml
 pipeline:
   hugo:
-    image: plugins/hugo:<HUGO_VERSION>
+    image: plugins/hugo:<RELEASE>
     config: path/to/config
     content: path/to/content/
     output: path/to/public
@@ -69,7 +69,7 @@ You can set the `buildDrafts`, `buildExpired`, `buildFuture` settings to configu
 ```yml
 pipeline:
   hugo:
-    image: plugins/hugo:<HUGO_VERSION>
+    image: plugins/hugo:<RELEASE>
 +   buildDrafts: true
 +   buildExpired: true
 +   buildFuture: true
@@ -89,7 +89,7 @@ Here is a short example of how to define a pipeline that automatically generates
 ```yml
 pipeline:
   build:
-    image: plugins/hugo:<HUGO_VERSION>
+    image: plugins/hugo:<RELEASE>
     output: site # Output path
     validate: true
     when:
@@ -109,7 +109,7 @@ You can also use secrets to hide credentials:
 ```yml
 pipeline:
   build:
-    image: plugins/hugo:<HUGO_VERSION>
+    image: plugins/hugo:<RELEASE>
     output: site # Output path
     validate: true
     when:
@@ -129,6 +129,7 @@ pipeline:
 
 ```bash
 docker run --rm \
+  -e PLUGIN_VERSION=<HUGO_VERSION> \
   -e PLUGIN_BUILDDRAFTS=false \
   -e PLUGIN_BUILDEXPIRED=false \
   -e PLUGIN_BUILDFUTURE=false \
@@ -147,6 +148,7 @@ docker run --rm \
 
 ## Parameter Reference
 
+`version` - the hugo version to be used, if not set use v.<HUGO_VERSION>  
 `buildDrafts` - include content marked as draft<br>
 `buildExpired` - include expired content<br>
 `buildFuture` - include content with publishdate in the future<br>

--- a/drone-hugo.sh
+++ b/drone-hugo.sh
@@ -3,6 +3,7 @@
 set -e
 
 # Assign default variables if not set
+PLUGIN_VERSION=${PLUGIN_VERSION:-"false"}
 PLUGIN_BUILDDRAFTS=${PLUGIN_BUILDDRAFTS:-"false"}
 PLUGIN_BUILDEXPIRED=${PLUGIN_BUILDEXPIRED:-"false"}
 PLUGIN_BUILDFUTURE=${PLUGIN_BUILDFUTURE:-"false"}
@@ -15,18 +16,28 @@ PLUGIN_THEME=${PLUGIN_THEME:-"false"}
 PLUGIN_URL=${PLUGIN_URL:-"false"}
 PLUGIN_VALIDATE=${PLUGIN_VALIDATE:-"false"}
 
+# The hugo command
+HUGO_COMMAND="hugo"
+
 function addArgument {
   echo $1
   HUGO_COMMAND="${HUGO_COMMAND} $1"
 }
 
-# Hugo Command
-HUGO_COMMAND="hugo"
+# Download hugo binary if version attribute is set. When not set, use the one shipped binary inside container
+if [[ $PLUGIN_VERSION != "false" ]] ; then
+  echo "Downloading hugo version v${PLUGIN_VERSION}..."
+  mkdir /temp/
+  wget -qO- https://github.com/gohugoio/hugo/releases/download/v${PLUGIN_VERSION}/hugo_${PLUGIN_VERSION}_Linux-64bit.tar.gz | tar xz -C /temp/
+  mv /temp/hugo /bin/hugo
+  rm  -rf /temp
+  echo "Using hugo v${PLUGIN_VERSION}..."
+fi
 
 # Validate config file
 if [[ $PLUGIN_VALIDATE = true ]]; then
-  echo "Checking config file ${PLUGIN_CONFIG}..."
   if [[ $PLUGIN_CONFIG != "false" ]]; then
+    echo "Checking config file ${PLUGIN_CONFIG}..."
     hugo check --config ${PLUGIN_CONFIG}
   else
     hugo check


### PR DESCRIPTION
I have defined a new attribute to set the Hugo version in the pipeline step - thanks to @tboerger for the idea!

This PR allows you to set the hugo version to be used over the attribute `version`. 

```
pipeline:
  build:
    pull: true
    image: cbrgm/drone-hugo:test
    version: 0.39
    output: cbrgm.de
    validate: true
```

Imagine a drone-plugins/drone-hugo release shipped with hugo version 0.40.
If the attribute `version` is not set, the binary shipped in the container is used (v.0.40). If the version attribute is set, the defined hugo version is downloaded and used instead of the version in the container (v.0.39). So the example above will result in the pipeline output:

```
Downloading hugo version v0.39...
Using hugo v0.39...
Contains some verification checks

--destination cbrgm.de
Executing: hugo --destination cbrgm.de
Building sites … 
                   | EN  
+------------------+----+
  Pages            | 80  
  Paginator pages  |  2  
  Non-page files   |  0  
  Static files     | 26  
  Processed images |  0  
  Aliases          | 34  
  Sitemaps         |  1  
  Cleaned          |  0  

Total in 93 ms
```

I also suggest tagging the new drone-plugins/drone-hugo images by plugin version instead of hugo version. So the new images will be available as plugins/drone-hugo:1.1 (and so on...).

I'm excited for your review!
