### PR TITLE
Add `cacheDir` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ docker run --rm \
   -e PLUGIN_BUILDDRAFTS=false \
   -e PLUGIN_BUILDEXPIRED=false \
   -e PLUGIN_BUILDFUTURE=false \
+  -e PLUGIN_CACHEDIR=false \
   -e PLUGIN_CONFIG=false \
   -e PLUGIN_CONTENT=false \
   -e PLUGIN_LAYOUT=false \
@@ -152,6 +153,7 @@ docker run --rm \
 `buildDrafts` - include content marked as draft<br>
 `buildExpired` - include expired content<br>
 `buildFuture` - include content with publishdate in the future<br>
+`cacheDir` - change cache directory (useful when using caching plugins)<br>
 `config` - config file (default is path/config.yaml|json|toml)<br>
 `content` - filesystem path to content directory<br>
 `layout` - filesystem path to layout directory<br>

--- a/docs/tmpl.md
+++ b/docs/tmpl.md
@@ -133,6 +133,7 @@ docker run --rm \
   -e PLUGIN_BUILDDRAFTS=false \
   -e PLUGIN_BUILDEXPIRED=false \
   -e PLUGIN_BUILDFUTURE=false \
+  -e PLUGIN_CACHEDIR=false \
   -e PLUGIN_CONFIG=false \
   -e PLUGIN_CONTENT=false \
   -e PLUGIN_LAYOUT=false \
@@ -152,6 +153,7 @@ docker run --rm \
 `buildDrafts` - include content marked as draft<br>
 `buildExpired` - include expired content<br>
 `buildFuture` - include content with publishdate in the future<br>
+`cacheDir` - change cache directory (useful when using caching plugins)
 `config` - config file (default is path/config.yaml|json|toml)<br>
 `content` - filesystem path to content directory<br>
 `layout` - filesystem path to layout directory<br>

--- a/drone-hugo.sh
+++ b/drone-hugo.sh
@@ -15,6 +15,7 @@ PLUGIN_SOURCE=${PLUGIN_SOURCE:-"false"}
 PLUGIN_THEME=${PLUGIN_THEME:-"false"}
 PLUGIN_URL=${PLUGIN_URL:-"false"}
 PLUGIN_VALIDATE=${PLUGIN_VALIDATE:-"false"}
+PLUGIN_CACHEDIR=${PLUGIN_CACHEDIR:-"false"}
 
 # The hugo command
 HUGO_COMMAND="hugo"
@@ -48,6 +49,7 @@ fi
 if [[ $PLUGIN_BUILDDRAFTS != "false" ]] ; then addArgument "-D" ; fi
 if [[ $PLUGIN_BUILDEXPIRED != "false" ]] ; then addArgument "-E" ; fi
 if [[ $PLUGIN_BUILDFUTURE != "false" ]] ; then addArgument "-F" ; fi
+if [[ $PLUGIN_CACHEDIR != "false" ]] ; then addArgument "--cacheDir ${PLUGIN_CACHEDIR}" ; fi
 if [[ $PLUGIN_CONFIG != "false" ]] ; then addArgument "--config ${PLUGIN_CONFIG}" ; fi
 if [[ $PLUGIN_CONTENT != "false" ]] ; then addArgument "--contentDir ${PLUGIN_CONFIG}" ; fi
 if [[ $PLUGIN_LAYOUT != "false" ]] ; then addArgument "--layoutDir ${PLUGIN_LAYOUT}" ; fi


### PR DESCRIPTION
This enables setting a custom cache directory for Hugo. Some caching
plugins (e.g. http://plugins.drone.io/drillster/drone-volume-cache/)
require the directories to be cached to be located inside the workspace.