### PR TITLE
add cacheDir flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ docker run --rm \
   -e PLUGIN_BUILDDRAFTS=false \
   -e PLUGIN_BUILDEXPIRED=false \
   -e PLUGIN_BUILDFUTURE=false \
+  -e PLUGIN_CACHEDIR=false \
   -e PLUGIN_CONFIG=false \
   -e PLUGIN_CONTENT=false \
   -e PLUGIN_LAYOUT=false \

--- a/cmd/drone-hugo/main.go
+++ b/cmd/drone-hugo/main.go
@@ -37,6 +37,12 @@ func main() {
 			EnvVar: "PLUGIN_BUILDFUTURE",
 		},
 		cli.StringFlag{
+			Name:   "cacheDir",
+			Usage:  "change cache directory (useful when using caching plugins)",
+			EnvVar: "PLUGIN_CACHEDIR",
+			Value:  "",
+		},
+		cli.StringFlag{
 			Name:   "config",
 			Usage:  "config file (default is path/config.yaml|json|toml)",
 			EnvVar: "PLUGIN_CONFIG",

--- a/plugin.go
+++ b/plugin.go
@@ -18,6 +18,7 @@ type (
 		BuildDrafts  bool
 		BuildExpired bool
 		BuildFuture  bool
+		CacheDir     string
 		Config       string
 		Content      string
 		Layout       string
@@ -75,6 +76,9 @@ func commandBuild(config Config) *exec.Cmd {
 		args = append(args, "-F")
 	}
 	// add string args
+	if config.CacheDir != "" {
+		args = append(args, "--cacheDir", config.CacheDir)
+	}
 	if config.Config != "" {
 		args = append(args, "--config", config.Config)
 	}


### PR DESCRIPTION
golang version of #7 

-----
This enables setting a custom cache directory for Hugo. Some caching
plugins (e.g. http://plugins.drone.io/drillster/drone-volume-cache/)
require the directories to be cached to be located inside the workspace.