### PR TITLE
Update hugo version & Remove validate command

### DIFF
--- a/.drone.windows.yml
+++ b/.drone.windows.yml
@@ -10,7 +10,7 @@ platform:
 steps:
 - name: vet
   pull: always
-  image: golang:1.14-windowsservercore-1803
+  image: golang:1.18.3-windowsservercore-1803
   commands:
   - go vet ./...
   environment:
@@ -21,7 +21,7 @@ steps:
 
 - name: test
   pull: always
-  image: golang:1.14-windowsservercore-1803
+  image: golang:1.18.3-windowsservercore-1803
   commands:
   - go test -cover ./...
   environment:
@@ -52,7 +52,7 @@ platform:
 steps:
 - name: build-push
   pull: always
-  image: golang:1.14-windowsservercore-1803
+  image: golang:1.18.3-windowsservercore-1803
   commands:
   - "go build -v -ldflags \"-X main.version=${DRONE_COMMIT_SHA:0:8}\" -a -tags netgo -o release/windows/amd64/drone-hugo.exe"
   environment:
@@ -65,7 +65,7 @@ steps:
 
 - name: build-tag
   pull: always
-  image: golang:1.14-windowsservercore-1803
+  image: golang:1.18.3-windowsservercore-1803
   commands:
   - "go build -v -ldflags \"-X main.version=${DRONE_TAG##v}\" -a -tags netgo -o release/windows/amd64/drone-hugo.exe"
   environment:
@@ -77,7 +77,7 @@ steps:
 
 - name: executable
   pull: always
-  image: golang:1.14-windowsservercore-1803
+  image: golang:1.18.3-windowsservercore-1803
   commands:
   - ./release/windows/amd64/drone-hugo.exe --help
 
@@ -148,7 +148,7 @@ platform:
 steps:
 - name: build-push
   pull: always
-  image: golang:1.14-windowsservercore-1809
+  image: golang:1.18.3-windowsservercore-1809
   commands:
   - "go build -v -ldflags \"-X main.version=${DRONE_COMMIT_SHA:0:8}\" -a -tags netgo -o release/windows/amd64/drone-hugo.exe"
   environment:
@@ -161,7 +161,7 @@ steps:
 
 - name: build-tag
   pull: always
-  image: golang:1.14-windowsservercore-1809
+  image: golang:1.18.3-windowsservercore-1809
   commands:
   - "go build -v -ldflags \"-X main.version=${DRONE_TAG##v}\" -a -tags netgo -o release/windows/amd64/drone-hugo.exe"
   environment:
@@ -173,7 +173,7 @@ steps:
 
 - name: executable
   pull: always
-  image: golang:1.14-windowsservercore-1809
+  image: golang:1.18.3-windowsservercore-1809
   commands:
   - ./release/windows/amd64/drone-hugo.exe --help
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -9,7 +9,7 @@ platform:
 steps:
 - name: vet
   pull: always
-  image: golang:1.14
+  image: golang:1.18.3
   commands:
   - go vet ./...
   environment:
@@ -20,7 +20,7 @@ steps:
 
 - name: test
   pull: always
-  image: golang:1.14
+  image: golang:1.18.3
   commands:
   - go test -cover ./...
   environment:
@@ -50,7 +50,7 @@ platform:
 steps:
 - name: build-push
   pull: always
-  image: golang:1.14
+  image: golang:1.18.3
   commands:
   - "go build -v -ldflags \"-X main.version=${DRONE_COMMIT_SHA:0:8}\" -a -tags netgo -o release/linux/amd64/drone-hugo"
   environment:
@@ -63,7 +63,7 @@ steps:
 
 - name: build-tag
   pull: always
-  image: golang:1.14
+  image: golang:1.18.3
   commands:
   - "go build -v -ldflags \"-X main.version=${DRONE_TAG##v}\" -a -tags netgo -o release/linux/amd64/drone-hugo"
   environment:
@@ -75,7 +75,7 @@ steps:
 
 - name: executable
   pull: always
-  image: golang:1.14
+  image: golang:1.18.3
   commands:
   - ./release/linux/amd64/drone-hugo --help
 
@@ -134,7 +134,7 @@ platform:
 steps:
 - name: build-push
   pull: always
-  image: golang:1.14
+  image: golang:1.18.3
   commands:
   - "go build -v -ldflags \"-X main.version=${DRONE_COMMIT_SHA:0:8}\" -a -tags netgo -o release/linux/arm64/drone-hugo"
   environment:
@@ -147,7 +147,7 @@ steps:
 
 - name: build-tag
   pull: always
-  image: golang:1.14
+  image: golang:1.18.3
   commands:
   - "go build -v -ldflags \"-X main.version=${DRONE_TAG##v}\" -a -tags netgo -o release/linux/arm64/drone-hugo"
   environment:
@@ -159,7 +159,7 @@ steps:
 
 - name: executable
   pull: always
-  image: golang:1.14
+  image: golang:1.18.3
   commands:
   - ./release/linux/arm64/drone-hugo --help
 
@@ -218,7 +218,7 @@ platform:
 steps:
 - name: build-push
   pull: always
-  image: golang:1.14
+  image: golang:1.18.3
   commands:
   - "go build -v -ldflags \"-X main.version=${DRONE_COMMIT_SHA:0:8}\" -a -tags netgo -o release/linux/arm/drone-hugo"
   environment:
@@ -231,7 +231,7 @@ steps:
 
 - name: build-tag
   pull: always
-  image: golang:1.14
+  image: golang:1.18.3
   commands:
   - "go build -v -ldflags \"-X main.version=${DRONE_TAG##v}\" -a -tags netgo -o release/linux/arm/drone-hugo"
   environment:
@@ -243,7 +243,7 @@ steps:
 
 - name: executable
   pull: always
-  image: golang:1.14
+  image: golang:1.18.3
   commands:
   - ./release/linux/arm/drone-hugo --help
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -311,13 +311,6 @@ steps:
     username:
       from_secret: docker_username
 
-- name: microbadger
-  pull: always
-  image: plugins/webhook
-  settings:
-    url:
-      from_secret: microbadger_url
-
 trigger:
   ref:
   - refs/heads/master

--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ docker run --rm \
   -e PLUGIN_SOURCE=false \
   -e PLUGIN_THEME=false \
   -e PLUGIN_OUTPUT=false \
-  -e PLUGIN_VALIDATE=false \
   -v $(pwd):$(pwd) \
   -w $(pwd) \
   plugins/hugo:latest

--- a/docker/Dockerfile.linux.amd64
+++ b/docker/Dockerfile.linux.amd64
@@ -1,7 +1,11 @@
-FROM amd64/golang:1.14-alpine AS build
+ARG GO_VERSION=1.18.3
+
+FROM amd64/golang:$GO_VERSION-alpine AS build
+
+ARG HUGO_VERSION=0.101.0
 
 RUN apk add --no-cache git build-base && \
-  git clone --branch v0.70.0 https://github.com/gohugoio/hugo.git && \
+  git clone --branch v$HUGO_VERSION https://github.com/gohugoio/hugo.git && \
   cd hugo/ && \
   CGO_ENABLED=0 go build -ldflags "-s -w -X github.com/gohugoio/hugo/common/hugo.buildDate=$(date +%Y-%m-%dT%H:%M:%SZ) -X github.com/gohugoio/hugo/common/hugo.commitHash=$(git rev-parse --short HEAD)" -o /tmp/hugo . && \
   CGO_ENABLED=1 go build -tags extended -ldflags "-s -w -X github.com/gohugoio/hugo/common/hugo.buildDate=$(date +%Y-%m-%dT%H:%M:%SZ) -X github.com/gohugoio/hugo/common/hugo.commitHash=$(git rev-parse --short HEAD)" -o /tmp/hugo-extended
@@ -13,10 +17,10 @@ LABEL maintainer="Drone.IO Community <drone-dev@googlegroups.com>" \
   org.label-schema.vendor="Drone.IO Community" \
   org.label-schema.schema-version="1.0"
 
-RUN apk --no-cache add git libc6-compat libstdc++
+RUN apk --no-cache --repository http://nl.alpinelinux.org/alpine/edge/main add git libc6-compat libstdc++
 
 ENV PLUGIN_HUGO_ARCH=64bit
-ENV PLUGIN_HUGO_SHIPPED_VERSION=0.70.0
+ENV PLUGIN_HUGO_SHIPPED_VERSION=0.101.0
 
 COPY --from=build /tmp/hugo /bin/hugo
 COPY --from=build /tmp/hugo-extended /bin/hugo-extended

--- a/docker/Dockerfile.linux.arm
+++ b/docker/Dockerfile.linux.arm
@@ -1,7 +1,11 @@
-FROM arm32v6/golang:1.14-alpine AS build
+ARG GO_VERSION=1.18.3
+
+FROM arm32v6/golang:$GO_VERSION-alpine AS build
+
+ARG HUGO_VERSION=0.101.0
 
 RUN apk add --no-cache git build-base && \
-  git clone --branch v0.70.0 https://github.com/gohugoio/hugo.git && \
+  git clone --branch v$HUGO_VERSION https://github.com/gohugoio/hugo.git && \
   cd hugo/ && \
   CGO_ENABLED=0 go build -ldflags "-s -w -X github.com/gohugoio/hugo/common/hugo.buildDate=$(date +%Y-%m-%dT%H:%M:%SZ) -X github.com/gohugoio/hugo/common/hugo.commitHash=$(git rev-parse --short HEAD)" -o /tmp/hugo . && \
   CGO_ENABLED=1 go build -tags extended -ldflags "-s -w -X github.com/gohugoio/hugo/common/hugo.buildDate=$(date +%Y-%m-%dT%H:%M:%SZ) -X github.com/gohugoio/hugo/common/hugo.commitHash=$(git rev-parse --short HEAD)" -o /tmp/hugo-extended
@@ -13,10 +17,10 @@ LABEL maintainer="Drone.IO Community <drone-dev@googlegroups.com>" \
   org.label-schema.vendor="Drone.IO Community" \
   org.label-schema.schema-version="1.0"
 
-RUN apk --no-cache add git libc6-compat libstdc++
+RUN apk --no-cache --repository http://nl.alpinelinux.org/alpine/edge/main add git libc6-compat libstdc++
 
 ENV PLUGIN_HUGO_ARCH=arm
-ENV PLUGIN_HUGO_SHIPPED_VERSION=0.70.0
+ENV PLUGIN_HUGO_SHIPPED_VERSION=0.101.0
 
 COPY --from=build /tmp/hugo /bin/hugo
 COPY --from=build /tmp/hugo-extended /bin/hugo-extended

--- a/docker/Dockerfile.linux.arm64
+++ b/docker/Dockerfile.linux.arm64
@@ -1,7 +1,11 @@
-FROM arm64v8/golang:1.14-alpine AS build
+ARG GO_VERSION=1.18.3
+
+FROM arm64v8/golang:$GO_VERSION-alpine AS build
+
+ARG HUGO_VERSION=0.101.0
 
 RUN apk add --no-cache git build-base && \
-  git clone --branch v0.70.0 https://github.com/gohugoio/hugo.git && \
+  git clone --branch v$HUGO_VERSION https://github.com/gohugoio/hugo.git && \
   cd hugo/ && \
   CGO_ENABLED=0 go build -ldflags "-s -w -X github.com/gohugoio/hugo/common/hugo.buildDate=$(date +%Y-%m-%dT%H:%M:%SZ) -X github.com/gohugoio/hugo/common/hugo.commitHash=$(git rev-parse --short HEAD)" -o /tmp/hugo . && \
   CGO_ENABLED=1 go build -tags extended -ldflags "-s -w -X github.com/gohugoio/hugo/common/hugo.buildDate=$(date +%Y-%m-%dT%H:%M:%SZ) -X github.com/gohugoio/hugo/common/hugo.commitHash=$(git rev-parse --short HEAD)" -o /tmp/hugo-extended
@@ -13,10 +17,10 @@ LABEL maintainer="Drone.IO Community <drone-dev@googlegroups.com>" \
   org.label-schema.vendor="Drone.IO Community" \
   org.label-schema.schema-version="1.0"
 
-RUN apk --no-cache add git libc6-compat libstdc++
+RUN apk --no-cache --repository http://nl.alpinelinux.org/alpine/edge/main add git libc6-compat libstdc++
 
 ENV PLUGIN_HUGO_ARCH=arm64
-ENV PLUGIN_HUGO_SHIPPED_VERSION=0.70.0
+ENV PLUGIN_HUGO_SHIPPED_VERSION=0.101.0
 
 COPY --from=build /tmp/hugo /bin/hugo
 COPY --from=build /tmp/hugo-extended /bin/hugo-extended

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,12 @@
 module github.com/drone-plugins/drone-hugo
 
+go 1.18
+
 require (
-	github.com/pkg/errors v0.8.1
-	github.com/urfave/cli v1.20.0
+	github.com/urfave/cli v1.22.9
+)
+
+require (
+	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
+	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,13 @@
-github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
-github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-github.com/urfave/cli v1.20.0 h1:fDqGv3UG/4jbVl/QkFwEdddtEDjh/5Ov6X+0B/3bPaw=
-github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
+github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
+github.com/cpuguy83/go-md2man/v2 v2.0.2 h1:p1EgwI/C7NhT0JmVkwCD2ZBK8j4aeHQX2pMHHBfMQ6w=
+github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
+github.com/urfave/cli v1.22.9 h1:cv3/KhXGBGjEXLC4bH0sLuJ9BewaAbpk5oyMOveu4pw=
+github.com/urfave/cli v1.22.9/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/main.go
+++ b/main.go
@@ -81,11 +81,6 @@ func main() {
 			EnvVar: "PLUGIN_URL",
 			Value:  "",
 		},
-		cli.BoolFlag{
-			Name:   "validate",
-			Usage:  "validate config file before generation",
-			EnvVar: "PLUGIN_VALIDATE",
-		},
 		cli.StringFlag{
 			Name:   "hugoversion",
 			Usage:  "the hugo version to be used",
@@ -110,7 +105,6 @@ func run(c *cli.Context) error {
 			Drafts:   c.Bool("drafts"),
 			Expired:  c.Bool("expired"),
 			Future:   c.Bool("future"),
-			Validate: c.Bool("validate"),
 			Config:   c.String("config"),
 			Content:  c.String("content"),
 			Layout:   c.String("layout"),

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -2,27 +2,7 @@ package main
 
 import (
 	"testing"
-
-	"github.com/pkg/errors"
 )
-
-func TestCommandValidate(t *testing.T) {
-	config := Config{Validate: true}
-	want := []string{"hugo", "check"}
-	got := commandValidate(config)
-
-	if err := argsEqual(want, got.Args); err != nil {
-		t.Errorf("%s", err)
-	}
-
-	config = Config{Validate: true, Config: "config.toml"}
-	want = []string{"hugo", "check", "--config", "config.toml"}
-	got = commandValidate(config)
-
-	if err := argsEqual(want, got.Args); err != nil {
-		t.Errorf("%s", err)
-	}
-}
 
 func TestVersionEqual(t *testing.T) {
 	want := true
@@ -34,13 +14,4 @@ func TestVersionEqual(t *testing.T) {
 	if got := versionsEqual("1.5", "1.0"); want != got {
 		t.Errorf("want: %t, got: %t", want, got)
 	}
-}
-
-func argsEqual(want []string, got []string) error {
-	for i := range want {
-		if want[i] != got[i] {
-			return errors.Errorf("Arguments do not match, want: %s, got: %s", want[i], got[i])
-		}
-	}
-	return nil
 }


### PR DESCRIPTION
- updated golang to 1.18.3
- updated hugo to 0.101.0
- BREAKING CHANGES: removed validate command  #33 
   hugo check was [removed by upstream](https://github.com/gohugoio/hugo/issues/9454)  (**[Discourse](https://discourse.gohugo.io/t/regenerating-cli-docs/36872/3)**)